### PR TITLE
Add caching scaffolding for DiT models

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -16,6 +16,36 @@ from diffusers.models import AutoencoderKL
 from download import find_model
 from models import DiT_models
 import argparse
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_cache_config():
+    try:
+        from diffusers.utils.dit_cache import CacheConfig
+        return CacheConfig
+    except ModuleNotFoundError:
+        cache_path = Path(__file__).resolve().parent / "src" / "diffusers" / "utils" / "dit_cache.py"
+        if not cache_path.exists():
+            raise
+        spec = importlib.util.spec_from_file_location("diffusers.utils.dit_cache", cache_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        try:
+            parent = importlib.import_module("diffusers.utils")
+        except ModuleNotFoundError:
+            parent = ModuleType("diffusers.utils")
+            sys.modules["diffusers.utils"] = parent
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module.CacheConfig
+
+
+CacheConfig = _load_cache_config()
 
 
 def main(args):
@@ -23,6 +53,12 @@ def main(args):
     torch.manual_seed(args.seed)
     torch.set_grad_enabled(False)
     device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    cache_config = CacheConfig.from_flags(
+        enable=args.cache_enable,
+        level=args.cache_level,
+        policy=args.cache_policy,
+    )
 
     if args.ckpt is None:
         assert args.model == "DiT-XL/2", "Only DiT-XL/2 models are available for auto-download."
@@ -33,7 +69,8 @@ def main(args):
     latent_size = args.image_size // 8
     model = DiT_models[args.model](
         input_size=latent_size,
-        num_classes=args.num_classes
+        num_classes=args.num_classes,
+        cache_config=cache_config,
     ).to(device)
     # Auto-download a pre-trained model or load a custom DiT checkpoint from train.py:
     ckpt_path = args.ckpt or f"DiT-XL-2-{args.image_size}x{args.image_size}.pt"
@@ -79,5 +116,20 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--ckpt", type=str, default=None,
                         help="Optional path to a DiT checkpoint (default: auto-download a pre-trained DiT-XL/2 model).")
+    parser.add_argument("--cache.enable", dest="cache_enable", type=str, default="false")
+    parser.add_argument(
+        "--cache.level",
+        dest="cache_level",
+        type=str,
+        choices=["none", "block", "attn"],
+        default="none",
+    )
+    parser.add_argument(
+        "--cache.policy",
+        dest="cache_policy",
+        type=str,
+        choices=["disabled"],
+        default="disabled",
+    )
     args = parser.parse_args()
     main(args)

--- a/src/diffusers/pipelines/dit/pipeline_dit.py
+++ b/src/diffusers/pipelines/dit/pipeline_dit.py
@@ -1,0 +1,27 @@
+"""Minimal DiT pipeline extension that threads cache configuration."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class DiTPipeline:
+    """Wrapper that forwards cache-related arguments to the transformer."""
+
+    def __init__(self, transformer: Any):
+        self.transformer = transformer
+
+    def __call__(
+        self,
+        *args: Any,
+        cache_config: Optional[Any] = None,
+        feature_cache: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if cache_config is not None and "cache_config" not in kwargs:
+            kwargs["cache_config"] = cache_config
+        if feature_cache is not None and "feature_cache" not in kwargs:
+            kwargs["feature_cache"] = feature_cache
+        return self.transformer(*args, **kwargs)
+
+
+__all__ = ["DiTPipeline"]

--- a/src/diffusers/utils/dit_cache.py
+++ b/src/diffusers/utils/dit_cache.py
@@ -1,0 +1,166 @@
+"""Utilities for DiT feature caching scaffolding.
+
+This module provides lightweight cache primitives that allow models and
+pipelines to share a common configuration object without committing to a
+particular caching strategy yet. The implementation intentionally keeps the
+behavior passive – unless caching is explicitly enabled the helpers are
+essentially no-ops, which makes them safe to wire into existing code paths
+without altering outputs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, MutableMapping, Optional
+
+
+class CacheLevel(str, Enum):
+    """Granularity levels that a cache implementation can target."""
+
+    NONE = "none"
+    BLOCK = "block"
+    ATTN = "attn"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "CacheLevel":
+        if value is None:
+            return cls.NONE
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+class CachePolicy(str, Enum):
+    """Policy names for cache eviction or bypass strategies."""
+
+    DISABLED = "disabled"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "CachePolicy":
+        if value is None:
+            return cls.DISABLED
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+@dataclass
+class CacheConfig:
+    """Configuration describing how caching should behave."""
+
+    enable: bool = False
+    level: CacheLevel = CacheLevel.NONE
+    policy: CachePolicy = CachePolicy.DISABLED
+
+    @classmethod
+    def from_flags(
+        cls,
+        enable: Any = False,
+        level: Any = CacheLevel.NONE,
+        policy: Any = CachePolicy.DISABLED,
+    ) -> "CacheConfig":
+        """Create a :class:`CacheConfig` from flag-style inputs."""
+
+        def _to_bool(value: Any) -> bool:
+            if isinstance(value, bool):
+                return value
+            if value is None:
+                return False
+            text = str(value).strip().lower()
+            if text in {"1", "true", "yes", "y"}:
+                return True
+            if text in {"0", "false", "no", "n", ""}:
+                return False
+            raise ValueError(f"Cannot convert {value!r} to bool")
+
+        return cls(
+            enable=_to_bool(enable),
+            level=CacheLevel.from_value(level),
+            policy=CachePolicy.from_value(policy),
+        )
+
+    @property
+    def active(self) -> bool:
+        """Return ``True`` if caching should be active."""
+
+        return bool(self.enable and self.level is not CacheLevel.NONE and self.policy is not CachePolicy.DISABLED)
+
+
+@dataclass
+class CacheMetrics:
+    """Bookkeeping metadata collected by :class:`FeatureCache`."""
+
+    block_inputs: int = 0
+    block_outputs: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    cached_blocks: int = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        return {
+            "block_inputs": self.block_inputs,
+            "block_outputs": self.block_outputs,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "cached_blocks": self.cached_blocks,
+        }
+
+
+@dataclass
+class FeatureCache:
+    """In-memory cache container for transformer features."""
+
+    config: CacheConfig = field(default_factory=CacheConfig)
+    store: MutableMapping[str, Any] = field(default_factory=dict)
+    metrics: CacheMetrics = field(default_factory=CacheMetrics)
+
+    def reset(self) -> None:
+        """Drop all cached values and metrics."""
+
+        self.store.clear()
+        self.metrics = CacheMetrics()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _block_key(self, block_index: int) -> str:
+        return f"block:{block_index}"
+
+    def _block_cache_active(self) -> bool:
+        return self.config.active and self.config.level in {CacheLevel.BLOCK, CacheLevel.ATTN}
+
+    # ------------------------------------------------------------------
+    # Public hooks
+    # ------------------------------------------------------------------
+    def on_block_input(self, block_index: int, hidden_states: Any) -> Any:
+        """Hook invoked before a block consumes its inputs."""
+
+        if not self._block_cache_active():
+            return hidden_states
+        self.metrics.block_inputs += 1
+        key = self._block_key(block_index)
+        if key in self.store:
+            self.metrics.cache_hits += 1
+            return self.store[key]
+        self.metrics.cache_misses += 1
+        return hidden_states
+
+    def on_block_output(self, block_index: int, hidden_states: Any) -> Any:
+        """Hook invoked after a block produces its outputs."""
+
+        if not self._block_cache_active():
+            return hidden_states
+        self.metrics.block_outputs += 1
+        key = self._block_key(block_index)
+        self.store[key] = hidden_states
+        self.metrics.cached_blocks = len(self.store)
+        return hidden_states
+
+
+__all__ = [
+    "CacheConfig",
+    "CacheLevel",
+    "CacheMetrics",
+    "CachePolicy",
+    "FeatureCache",
+]

--- a/tests/test_cache_scaffolding.py
+++ b/tests/test_cache_scaffolding.py
@@ -1,0 +1,111 @@
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from models import DiT
+
+
+def _load_module(name: str, relative_path: Path):
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        spec = importlib.util.spec_from_file_location(name, relative_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        parent_name = name.rsplit(".", 1)[0]
+        if parent_name not in sys.modules:
+            try:
+                parent_module = importlib.import_module(parent_name)
+            except ModuleNotFoundError:
+                parent_module = ModuleType(parent_name)
+                sys.modules[parent_name] = parent_module
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+def _root_path() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def load_cache_components():
+    module_path = _root_path() / "src" / "diffusers" / "utils" / "dit_cache.py"
+    module = _load_module("diffusers.utils.dit_cache", module_path)
+    return module.CacheConfig, module.CacheLevel, module.CachePolicy
+
+
+def load_pipeline():
+    module_path = _root_path() / "src" / "diffusers" / "pipelines" / "dit" / "pipeline_dit.py"
+    return _load_module("diffusers.pipelines.dit.pipeline_dit", module_path)
+
+
+CacheConfig, CacheLevel, CachePolicy = load_cache_components()
+
+
+def make_model(cache_config=None):
+    kwargs = dict(
+        input_size=8,
+        patch_size=2,
+        in_channels=4,
+        hidden_size=32,
+        depth=2,
+        num_heads=4,
+        mlp_ratio=2.0,
+        class_dropout_prob=0.0,
+        num_classes=10,
+        learn_sigma=False,
+        cache_config=cache_config,
+    )
+    return DiT(**kwargs)
+
+
+def test_model_initialization_equivalence():
+    torch.manual_seed(0)
+    model_plain = make_model()
+    torch.manual_seed(0)
+    model_cached = make_model(CacheConfig(enable=False, level=CacheLevel.NONE, policy=CachePolicy.DISABLED))
+    plain_state = dict(model_plain.state_dict())
+    cached_state = dict(model_cached.state_dict())
+    assert plain_state.keys() == cached_state.keys()
+    for key in plain_state:
+        assert torch.equal(plain_state[key], cached_state[key])
+
+
+def test_forward_equivalence_when_cache_disabled():
+    torch.manual_seed(0)
+    model_plain = make_model()
+    torch.manual_seed(0)
+    model_cached = make_model(CacheConfig(enable=False, level=CacheLevel.NONE, policy=CachePolicy.DISABLED))
+    model_plain.eval()
+    model_cached.eval()
+    x = torch.randn(2, 4, 8, 8)
+    t = torch.randint(0, 1000, (2,))
+    y = torch.randint(0, 10, (2,))
+    with torch.no_grad():
+        out_plain = model_plain(x, t, y)
+        out_cached = model_cached(x, t, y)
+    assert torch.allclose(out_plain, out_cached)
+
+
+def test_pipeline_threads_cache_config():
+    module = load_pipeline()
+    cfg = CacheConfig(enable=True, level=CacheLevel.BLOCK, policy=CachePolicy.DISABLED)
+
+    class DummyTransformer:
+        def __call__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            return kwargs
+
+    transformer = DummyTransformer()
+    pipeline = module.DiTPipeline(transformer)
+    result = pipeline(1, 2, cache_config=cfg)
+    assert transformer.kwargs.get("cache_config") is cfg
+    assert result is transformer.kwargs


### PR DESCRIPTION
## Summary
- add a reusable cache configuration/metrics helper and minimal pipeline wrapper for DiT
- wire the DiT model, train, and sample entrypoints to accept optional cache configuration
- add regression tests that validate disabled-cache parity and cache threading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df8d23947c8330871672b691b63f9e