### PR TITLE
Implement block-level SmoothCache reuse

### DIFF
--- a/models.py
+++ b/models.py
@@ -13,6 +13,12 @@ import torch
 import torch.nn as nn
 import numpy as np
 import math
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Optional
 from timm.models.vision_transformer import PatchEmbed, Attention, Mlp
 
 
@@ -115,10 +121,12 @@ class DiTBlock(nn.Module):
             nn.Linear(hidden_size, 6 * hidden_size, bias=True)
         )
 
-    def forward(self, x, c):
+    def forward(self, x, c, cache_context=None):
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaLN_modulation(c).chunk(6, dim=1)
         x = x + gate_msa.unsqueeze(1) * self.attn(modulate(self.norm1(x), shift_msa, scale_msa))
         x = x + gate_mlp.unsqueeze(1) * self.mlp(modulate(self.norm2(x), shift_mlp, scale_mlp))
+        if cache_context is not None:
+            x = cache_context.blend(x)
         return x
 
 
@@ -142,6 +150,31 @@ class FinalLayer(nn.Module):
         return x
 
 
+def _load_cache_components():
+    try:
+        from diffusers.utils.dit_cache import CacheConfig, FeatureCache
+        return CacheConfig, FeatureCache
+    except ModuleNotFoundError:
+        cache_path = Path(__file__).resolve().parent / "src" / "diffusers" / "utils" / "dit_cache.py"
+        if not cache_path.exists():
+            raise
+        spec = importlib.util.spec_from_file_location("diffusers.utils.dit_cache", cache_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        try:
+            parent = importlib.import_module("diffusers.utils")
+        except ModuleNotFoundError:
+            parent = ModuleType("diffusers.utils")
+            sys.modules["diffusers.utils"] = parent
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module.CacheConfig, module.FeatureCache
+
+
+CacheConfig, FeatureCache = _load_cache_components()
+
+
 class DiT(nn.Module):
     """
     Diffusion model with a Transformer backbone.
@@ -158,6 +191,7 @@ class DiT(nn.Module):
         class_dropout_prob=0.1,
         num_classes=1000,
         learn_sigma=True,
+        cache_config: Optional[CacheConfig] = None,
     ):
         super().__init__()
         self.learn_sigma = learn_sigma
@@ -177,6 +211,7 @@ class DiT(nn.Module):
             DiTBlock(hidden_size, num_heads, mlp_ratio=mlp_ratio) for _ in range(depth)
         ])
         self.final_layer = FinalLayer(hidden_size, patch_size, self.out_channels)
+        self.cache_config = cache_config
         self.initialize_weights()
 
     def initialize_weights(self):
@@ -230,7 +265,14 @@ class DiT(nn.Module):
         imgs = x.reshape(shape=(x.shape[0], c, h * p, h * p))
         return imgs
 
-    def forward(self, x, t, y):
+    def forward(
+        self,
+        x,
+        t,
+        y,
+        cache_config: Optional[CacheConfig] = None,
+        feature_cache: Optional[FeatureCache] = None,
+    ):
         """
         Forward pass of DiT.
         x: (N, C, H, W) tensor of spatial inputs (images or latent representations of images)
@@ -241,20 +283,50 @@ class DiT(nn.Module):
         t = self.t_embedder(t)                   # (N, D)
         y = self.y_embedder(y, self.training)    # (N, D)
         c = t + y                                # (N, D)
-        for block in self.blocks:
-            x = block(x, c)                      # (N, T, D)
+        active_cache = feature_cache
+        resolved_config = cache_config or self.cache_config
+        if active_cache is None and resolved_config is not None and resolved_config.active:
+            active_cache = FeatureCache(resolved_config)
+        if active_cache is not None:
+            step_value = None
+            try:
+                step_value = int(t.reshape(-1)[0].item())
+            except Exception:  # pragma: no cover - best-effort extraction
+                step_value = None
+            active_cache.on_step_start(step_value)
+        for block_idx, block in enumerate(self.blocks):
+            cache_context = None
+            if active_cache is not None:
+                x, cache_context = active_cache.on_block_input(block_idx, x)
+            x = block(x, c, cache_context=cache_context)  # (N, T, D)
+            if active_cache is not None:
+                x = active_cache.on_block_output(block_idx, x, cache_context=cache_context)
         x = self.final_layer(x, c)                # (N, T, patch_size ** 2 * out_channels)
         x = self.unpatchify(x)                   # (N, out_channels, H, W)
         return x
 
-    def forward_with_cfg(self, x, t, y, cfg_scale):
+    def forward_with_cfg(
+        self,
+        x,
+        t,
+        y,
+        cfg_scale,
+        cache_config: Optional[CacheConfig] = None,
+        feature_cache: Optional[FeatureCache] = None,
+    ):
         """
         Forward pass of DiT, but also batches the unconditional forward pass for classifier-free guidance.
         """
         # https://github.com/openai/glide-text2im/blob/main/notebooks/text2im.ipynb
         half = x[: len(x) // 2]
         combined = torch.cat([half, half], dim=0)
-        model_out = self.forward(combined, t, y)
+        model_out = self.forward(
+            combined,
+            t,
+            y,
+            cache_config=cache_config,
+            feature_cache=feature_cache,
+        )
         # For exact reproducibility reasons, we apply classifier-free guidance on only
         # three channels by default. The standard approach to cfg applies it to all channels.
         # This can be done by uncommenting the following line and commenting-out the line following that.

--- a/sample.py
+++ b/sample.py
@@ -16,6 +16,36 @@ from diffusers.models import AutoencoderKL
 from download import find_model
 from models import DiT_models
 import argparse
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_cache_config():
+    try:
+        from diffusers.utils.dit_cache import CacheConfig
+        return CacheConfig
+    except ModuleNotFoundError:
+        cache_path = Path(__file__).resolve().parent / "src" / "diffusers" / "utils" / "dit_cache.py"
+        if not cache_path.exists():
+            raise
+        spec = importlib.util.spec_from_file_location("diffusers.utils.dit_cache", cache_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        try:
+            parent = importlib.import_module("diffusers.utils")
+        except ModuleNotFoundError:
+            parent = ModuleType("diffusers.utils")
+            sys.modules["diffusers.utils"] = parent
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module.CacheConfig
+
+
+CacheConfig = _load_cache_config()
 
 
 def main(args):
@@ -23,6 +53,16 @@ def main(args):
     torch.manual_seed(args.seed)
     torch.set_grad_enabled(False)
     device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    cache_config = CacheConfig.from_flags(
+        enable=args.cache_enable,
+        level=args.cache_level,
+        policy=args.cache_policy,
+        delta=args.cache_delta,
+        alpha=args.cache_alpha,
+        cosine_threshold=args.cache_cosine_threshold,
+        warmup_steps=args.cache_warmup_steps,
+    )
 
     if args.ckpt is None:
         assert args.model == "DiT-XL/2", "Only DiT-XL/2 models are available for auto-download."
@@ -33,7 +73,8 @@ def main(args):
     latent_size = args.image_size // 8
     model = DiT_models[args.model](
         input_size=latent_size,
-        num_classes=args.num_classes
+        num_classes=args.num_classes,
+        cache_config=cache_config,
     ).to(device)
     # Auto-download a pre-trained model or load a custom DiT checkpoint from train.py:
     ckpt_path = args.ckpt or f"DiT-XL-2-{args.image_size}x{args.image_size}.pt"
@@ -79,5 +120,34 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--ckpt", type=str, default=None,
                         help="Optional path to a DiT checkpoint (default: auto-download a pre-trained DiT-XL/2 model).")
+    parser.add_argument("--cache.enable", dest="cache_enable", type=str, default="false")
+    parser.add_argument(
+        "--cache.level",
+        dest="cache_level",
+        type=str,
+        choices=["none", "block", "attn"],
+        default="none",
+    )
+    parser.add_argument(
+        "--cache.policy",
+        dest="cache_policy",
+        type=str,
+        choices=["disabled"],
+        default="disabled",
+    )
+    parser.add_argument("--cache.delta", dest="cache_delta", type=int, default=1)
+    parser.add_argument("--cache.alpha", dest="cache_alpha", type=float, default=1.0)
+    parser.add_argument(
+        "--cache.cosine-threshold",
+        dest="cache_cosine_threshold",
+        type=float,
+        default=1.0,
+    )
+    parser.add_argument(
+        "--cache.warmup-steps",
+        dest="cache_warmup_steps",
+        type=int,
+        default=0,
+    )
     args = parser.parse_args()
     main(args)

--- a/src/diffusers/pipelines/dit/pipeline_dit.py
+++ b/src/diffusers/pipelines/dit/pipeline_dit.py
@@ -1,0 +1,27 @@
+"""Minimal DiT pipeline extension that threads cache configuration."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class DiTPipeline:
+    """Wrapper that forwards cache-related arguments to the transformer."""
+
+    def __init__(self, transformer: Any):
+        self.transformer = transformer
+
+    def __call__(
+        self,
+        *args: Any,
+        cache_config: Optional[Any] = None,
+        feature_cache: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if cache_config is not None and "cache_config" not in kwargs:
+            kwargs["cache_config"] = cache_config
+        if feature_cache is not None and "feature_cache" not in kwargs:
+            kwargs["feature_cache"] = feature_cache
+        return self.transformer(*args, **kwargs)
+
+
+__all__ = ["DiTPipeline"]

--- a/src/diffusers/utils/dit_cache.py
+++ b/src/diffusers/utils/dit_cache.py
@@ -1,0 +1,425 @@
+"""Utilities for DiT feature caching scaffolding.
+
+This module provides lightweight cache primitives that allow models and
+pipelines to share a common configuration object while progressively layering
+in richer cache behaviours.  The implementation intentionally keeps the
+behavior passive – unless caching is explicitly enabled the helpers are
+essentially no-ops, which makes them safe to wire into existing code paths
+without altering outputs when disabled.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+import logging
+from typing import Any, Deque, Dict, MutableMapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class CacheLevel(str, Enum):
+    """Granularity levels that a cache implementation can target."""
+
+    NONE = "none"
+    BLOCK = "block"
+    ATTN = "attn"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "CacheLevel":
+        if value is None:
+            return cls.NONE
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+class CachePolicy(str, Enum):
+    """Policy names for cache eviction or bypass strategies."""
+
+    DISABLED = "disabled"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "CachePolicy":
+        if value is None:
+            return cls.DISABLED
+        if isinstance(value, cls):
+            return value
+        return cls(str(value))
+
+
+@dataclass
+class CacheConfig:
+    """Configuration describing how caching should behave."""
+
+    enable: bool = False
+    level: CacheLevel = CacheLevel.NONE
+    policy: CachePolicy = CachePolicy.DISABLED
+    delta: int = 1
+    alpha: float = 1.0
+    cosine_threshold: float = 1.0
+    warmup_steps: int = 0
+
+    def __post_init__(self) -> None:
+        if self.delta < 0:
+            raise ValueError("cache delta must be non-negative")
+        if not 0.0 <= self.alpha <= 1.0:
+            raise ValueError("cache alpha must lie in [0, 1]")
+        if self.warmup_steps < 0:
+            raise ValueError("cache warmup_steps must be non-negative")
+
+    @classmethod
+    def from_flags(
+        cls,
+        enable: Any = False,
+        level: Any = CacheLevel.NONE,
+        policy: Any = CachePolicy.DISABLED,
+        delta: Any = 1,
+        alpha: Any = 1.0,
+        cosine_threshold: Any = 1.0,
+        warmup_steps: Any = 0,
+    ) -> "CacheConfig":
+        """Create a :class:`CacheConfig` from flag-style inputs."""
+
+        def _to_bool(value: Any) -> bool:
+            if isinstance(value, bool):
+                return value
+            if value is None:
+                return False
+            text = str(value).strip().lower()
+            if text in {"1", "true", "yes", "y"}:
+                return True
+            if text in {"0", "false", "no", "n", ""}:
+                return False
+            raise ValueError(f"Cannot convert {value!r} to bool")
+
+        def _to_int(value: Any, *, allow_none: bool = False) -> int:
+            if value is None:
+                if allow_none:
+                    return 0
+                raise ValueError("Integer flag may not be None")
+            if isinstance(value, int):
+                return value
+            return int(str(value).strip())
+
+        def _to_float(value: Any) -> float:
+            if value is None:
+                return 0.0
+            if isinstance(value, float):
+                return value
+            if isinstance(value, int):
+                return float(value)
+            return float(str(value).strip())
+
+        return cls(
+            enable=_to_bool(enable),
+            level=CacheLevel.from_value(level),
+            policy=CachePolicy.from_value(policy),
+            delta=max(0, _to_int(delta, allow_none=True)),
+            alpha=_to_float(alpha),
+            cosine_threshold=_to_float(cosine_threshold),
+            warmup_steps=max(0, _to_int(warmup_steps, allow_none=True)),
+        )
+
+    @property
+    def active(self) -> bool:
+        """Return ``True`` if caching should be active."""
+
+        return bool(
+            self.enable
+            and self.level is not CacheLevel.NONE
+        )
+
+
+@dataclass
+class BlockTelemetry:
+    """Per-block telemetry tracking acceptance rates and cosine stats."""
+
+    attempts: int = 0
+    accepts: int = 0
+    cosine_sum: float = 0.0
+    cosine_count: int = 0
+
+    def record(self, cosine: Optional[float], accepted: bool) -> None:
+        self.attempts += 1
+        if cosine is not None:
+            self.cosine_sum += float(cosine)
+            self.cosine_count += 1
+        if accepted:
+            self.accepts += 1
+
+    @property
+    def acceptance_rate(self) -> float:
+        if self.attempts == 0:
+            return 0.0
+        return self.accepts / self.attempts
+
+    @property
+    def average_cosine(self) -> float:
+        if self.cosine_count == 0:
+            return 0.0
+        return self.cosine_sum / self.cosine_count
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "attempts": self.attempts,
+            "acceptance_rate": self.acceptance_rate,
+            "average_cosine": self.average_cosine,
+        }
+
+
+@dataclass
+class CacheMetrics:
+    """Bookkeeping metadata collected by :class:`FeatureCache`."""
+
+    block_inputs: int = 0
+    block_outputs: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    cached_blocks: int = 0
+    block_telemetry: Dict[int, BlockTelemetry] = field(default_factory=dict)
+    latency_samples: Deque[float] = field(default_factory=deque)
+
+    def record_block_telemetry(self, block_index: int, cosine: Optional[float], accepted: bool) -> None:
+        telemetry = self.block_telemetry.setdefault(block_index, BlockTelemetry())
+        telemetry.record(cosine, accepted)
+
+    def record_latency(self, seconds: float) -> None:
+        self.latency_samples.append(float(seconds))
+
+    def as_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "block_inputs": self.block_inputs,
+            "block_outputs": self.block_outputs,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "cached_blocks": self.cached_blocks,
+        }
+        if self.block_telemetry:
+            data["block_telemetry"] = {
+                str(index): telemetry.as_dict()
+                for index, telemetry in self.block_telemetry.items()
+            }
+        if self.latency_samples:
+            count = len(self.latency_samples)
+            average = sum(self.latency_samples) / count
+            data["latency"] = {"count": count, "average_seconds": average}
+        return data
+
+
+@dataclass
+class BlockCacheContext:
+    """Context container passed to blocks while caching is active."""
+
+    cache: "FeatureCache"
+    block_index: int
+    target_iteration: Optional[int]
+    cached: Optional[Any]
+    accepted: bool = False
+    cosine: Optional[float] = None
+    processed: bool = False
+
+    def blend(self, hidden_states: Any) -> Any:
+        self.processed = True
+        return self.cache._blend_block_output(self, hidden_states)
+
+
+@dataclass
+class FeatureCache:
+    """In-memory cache container for transformer features."""
+
+    config: CacheConfig = field(default_factory=CacheConfig)
+    store: MutableMapping[str, Deque[Tuple[int, Any]]] = field(default_factory=dict)
+    metrics: CacheMetrics = field(default_factory=CacheMetrics)
+    _iteration: int = 0
+    _current_iteration: Optional[int] = None
+    _current_timestep: Optional[int] = None
+
+    def reset(self) -> None:
+        """Drop all cached values and metrics."""
+
+        self.store.clear()
+        self.metrics = CacheMetrics()
+        self._iteration = 0
+        self._current_iteration = None
+        self._current_timestep = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _block_key(self, block_index: int) -> str:
+        return f"block:{block_index}"
+
+    def _block_cache_active(self) -> bool:
+        return self.config.active and self.config.level in {CacheLevel.BLOCK, CacheLevel.ATTN}
+
+    def _history_length(self) -> int:
+        return max(1, int(self.config.delta) + 1)
+
+    def _get_block_store(self, block_index: int) -> Deque[Tuple[int, Any]]:
+        key = self._block_key(block_index)
+        if key not in self.store:
+            self.store[key] = deque(maxlen=self._history_length())
+        return self.store[key]
+
+    def _retrieve_cached(self, block_index: int, target_iteration: Optional[int]) -> Optional[Any]:
+        if target_iteration is None or target_iteration <= 0:
+            return None
+        key = self._block_key(block_index)
+        block_store = self.store.get(key)
+        if not block_store:
+            return None
+        for iteration, value in reversed(block_store):
+            if iteration == target_iteration:
+                return value
+        return None
+
+    def _blend_block_output(self, context: BlockCacheContext, hidden_states: Any) -> Any:
+        if not self._block_cache_active():
+            return hidden_states
+        cached = context.cached
+        block_index = context.block_index
+        if cached is None:
+            self.metrics.cache_misses += 1
+            self.metrics.record_block_telemetry(block_index, None, False)
+            context.accepted = False
+            context.cosine = None
+            return hidden_states
+        try:
+            import torch
+            import torch.nn.functional as F
+        except ModuleNotFoundError as exc:  # pragma: no cover - torch is required when caching is active
+            raise RuntimeError("FeatureCache requires torch to blend hidden states") from exc
+
+        candidate = cached
+        if candidate.device != hidden_states.device:
+            candidate = candidate.to(hidden_states.device)
+        if candidate.dtype != hidden_states.dtype:
+            candidate = candidate.to(hidden_states.dtype)
+
+        current_flat = hidden_states.reshape(hidden_states.shape[0], -1)
+        cached_flat = candidate.reshape(candidate.shape[0], -1)
+        cosine_per_sample = F.cosine_similarity(current_flat, cached_flat, dim=1, eps=1e-6)
+        cosine_value = float(cosine_per_sample.mean().detach().item())
+        threshold = float(self.config.cosine_threshold)
+        accepted = cosine_value >= threshold
+        context.cosine = cosine_value
+        context.accepted = accepted
+        self.metrics.record_block_telemetry(block_index, cosine_value, accepted)
+        logger.debug(
+            "cache block %s iteration=%s cosine=%.4f threshold=%.4f accepted=%s",
+            block_index,
+            self._current_iteration,
+            cosine_value,
+            threshold,
+            accepted,
+        )
+        if not accepted:
+            self.metrics.cache_misses += 1
+            return hidden_states
+
+        self.metrics.cache_hits += 1
+        alpha = float(self.config.alpha)
+        if alpha >= 1.0:
+            return hidden_states
+        blended = hidden_states.mul(alpha).add(candidate, alpha=1 - alpha)
+        return blended
+
+    def _record_cached_block(self, block_index: int, hidden_states: Any) -> None:
+        if not self._block_cache_active():
+            return
+        store = self._get_block_store(block_index)
+        iteration = self._current_iteration
+        if iteration is None:
+            return
+        store.append((iteration, hidden_states.detach()))
+        self.metrics.cached_blocks = sum(1 for values in self.store.values() if values)
+
+    # ------------------------------------------------------------------
+    # Public hooks
+    # ------------------------------------------------------------------
+    def on_step_start(self, timestep: Optional[int] = None) -> None:
+        if not self._block_cache_active():
+            return
+        self._iteration += 1
+        self._current_iteration = self._iteration
+        self._current_timestep = timestep
+
+    def record_latency(self, seconds: float) -> None:
+        if not self._block_cache_active():
+            return
+        self.metrics.record_latency(seconds)
+        logger.info("cache latency %.3fms", seconds * 1000.0)
+
+    def on_block_input(self, block_index: int, hidden_states: Any) -> Tuple[Any, Optional[BlockCacheContext]]:
+        """Hook invoked before a block consumes its inputs."""
+
+        if not self._block_cache_active():
+            return hidden_states, None
+        self.metrics.block_inputs += 1
+        if self._current_iteration is None or self._current_iteration <= self.config.warmup_steps:
+            context = BlockCacheContext(
+                cache=self,
+                block_index=block_index,
+                target_iteration=None,
+                cached=None,
+            )
+            return hidden_states, context
+        target_iteration = self._current_iteration - int(self.config.delta)
+        cached = self._retrieve_cached(block_index, target_iteration)
+        context = BlockCacheContext(
+            cache=self,
+            block_index=block_index,
+            target_iteration=target_iteration,
+            cached=cached,
+        )
+        return hidden_states, context
+
+    def on_block_output(
+        self,
+        block_index: int,
+        hidden_states: Any,
+        cache_context: Optional[BlockCacheContext] = None,
+    ) -> Any:
+        """Hook invoked after a block produces its outputs."""
+
+        if not self._block_cache_active():
+            return hidden_states
+        self.metrics.block_outputs += 1
+        result = hidden_states
+        if cache_context is not None:
+            if not cache_context.processed:
+                result = cache_context.blend(hidden_states)
+        else:
+            # No context implies the block was not able to retrieve cached features.
+            self.metrics.cache_misses += 1
+        self._record_cached_block(block_index, result)
+        return result
+
+    def log_summary(self) -> None:
+        """Log a summary of cache telemetry for debugging purposes."""
+
+        if not self.metrics.block_telemetry:
+            return
+        for block_index, telemetry in sorted(self.metrics.block_telemetry.items()):
+            logger.info(
+                "cache block %s acceptance_rate=%.3f avg_cosine=%.4f attempts=%d",
+                block_index,
+                telemetry.acceptance_rate,
+                telemetry.average_cosine,
+                telemetry.attempts,
+            )
+        if self.metrics.latency_samples:
+            count = len(self.metrics.latency_samples)
+            average = sum(self.metrics.latency_samples) / count
+            logger.info("cache latency avg=%.3fms samples=%d", average * 1000.0, count)
+
+
+__all__ = [
+    "CacheConfig",
+    "CacheLevel",
+    "CacheMetrics",
+    "CachePolicy",
+    "BlockTelemetry",
+    "FeatureCache",
+]

--- a/tests/test_cache_scaffolding.py
+++ b/tests/test_cache_scaffolding.py
@@ -1,0 +1,181 @@
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+# Ensure the project root (which contains `models.py`) is importable when the
+# test file is executed directly, e.g. ``python tests/test_cache_scaffolding.py``.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models import DiT
+
+
+def _load_module(name: str, relative_path: Path):
+    try:
+        return importlib.import_module(name)
+    except ModuleNotFoundError:
+        spec = importlib.util.spec_from_file_location(name, relative_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        parent_name = name.rsplit(".", 1)[0]
+        if parent_name not in sys.modules:
+            try:
+                parent_module = importlib.import_module(parent_name)
+            except ModuleNotFoundError:
+                parent_module = ModuleType(parent_name)
+                sys.modules[parent_name] = parent_module
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+def _root_path() -> Path:
+    return PROJECT_ROOT
+
+
+def load_cache_components():
+    module_path = _root_path() / "src" / "diffusers" / "utils" / "dit_cache.py"
+    module = _load_module("diffusers.utils.dit_cache", module_path)
+    return module.CacheConfig, module.CacheLevel, module.CachePolicy, module.FeatureCache
+
+
+def load_pipeline():
+    module_path = _root_path() / "src" / "diffusers" / "pipelines" / "dit" / "pipeline_dit.py"
+    return _load_module("diffusers.pipelines.dit.pipeline_dit", module_path)
+
+
+CacheConfig, CacheLevel, CachePolicy, FeatureCache = load_cache_components()
+
+
+def make_model(cache_config=None):
+    kwargs = dict(
+        input_size=8,
+        patch_size=2,
+        in_channels=4,
+        hidden_size=32,
+        depth=2,
+        num_heads=4,
+        mlp_ratio=2.0,
+        class_dropout_prob=0.0,
+        num_classes=10,
+        learn_sigma=False,
+        cache_config=cache_config,
+    )
+    return DiT(**kwargs)
+
+
+def test_model_initialization_equivalence():
+    torch.manual_seed(0)
+    model_plain = make_model()
+    torch.manual_seed(0)
+    model_cached = make_model(CacheConfig(enable=False, level=CacheLevel.NONE, policy=CachePolicy.DISABLED))
+    plain_state = dict(model_plain.state_dict())
+    cached_state = dict(model_cached.state_dict())
+    assert plain_state.keys() == cached_state.keys()
+    for key in plain_state:
+        assert torch.equal(plain_state[key], cached_state[key])
+
+
+def test_forward_equivalence_when_cache_disabled():
+    torch.manual_seed(0)
+    model_plain = make_model()
+    torch.manual_seed(0)
+    model_cached = make_model(CacheConfig(enable=False, level=CacheLevel.NONE, policy=CachePolicy.DISABLED))
+    model_plain.eval()
+    model_cached.eval()
+    x = torch.randn(2, 4, 8, 8)
+    t = torch.randint(0, 1000, (2,))
+    y = torch.randint(0, 10, (2,))
+    with torch.no_grad():
+        out_plain = model_plain(x, t, y)
+        out_cached = model_cached(x, t, y)
+    assert torch.allclose(out_plain, out_cached)
+
+
+def test_pipeline_threads_cache_config():
+    module = load_pipeline()
+    cfg = CacheConfig(enable=True, level=CacheLevel.BLOCK, policy=CachePolicy.DISABLED)
+
+    class DummyTransformer:
+        def __call__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            return kwargs
+
+    transformer = DummyTransformer()
+    pipeline = module.DiTPipeline(transformer)
+    result = pipeline(1, 2, cache_config=cfg)
+    assert transformer.kwargs.get("cache_config") is cfg
+    assert result is transformer.kwargs
+
+
+def _synchronize_models(cache_config):
+    torch.manual_seed(0)
+    base = make_model()
+    torch.manual_seed(0)
+    cached = make_model(cache_config)
+    cached.load_state_dict(base.state_dict())
+    return base, cached
+
+
+def test_block_cache_alpha_one_preserves_outputs():
+    cfg = CacheConfig(
+        enable=True,
+        level=CacheLevel.BLOCK,
+        policy=CachePolicy.DISABLED,
+        alpha=1.0,
+        cosine_threshold=-1.0,
+    )
+    model_plain, model_cached = _synchronize_models(cfg)
+    feature_cache = FeatureCache(cfg)
+    model_plain.eval()
+    model_cached.eval()
+    x0 = torch.randn(2, 4, 8, 8)
+    t0 = torch.full((2,), 5)
+    y = torch.randint(0, 10, (2,))
+    with torch.no_grad():
+        out_plain_0 = model_plain(x0, t0, y)
+        out_cached_0 = model_cached(x0, t0, y, cache_config=cfg, feature_cache=feature_cache)
+    assert torch.allclose(out_plain_0, out_cached_0)
+    x1 = torch.randn(2, 4, 8, 8)
+    t1 = torch.full((2,), 4)
+    with torch.no_grad():
+        out_plain_1 = model_plain(x1, t1, y)
+        out_cached_1 = model_cached(x1, t1, y, cache_config=cfg, feature_cache=feature_cache)
+    assert torch.allclose(out_plain_1, out_cached_1)
+    assert feature_cache.metrics.cache_hits >= 1
+
+
+def test_block_cache_threshold_bypass_matches_baseline():
+    cfg = CacheConfig(
+        enable=True,
+        level=CacheLevel.BLOCK,
+        policy=CachePolicy.DISABLED,
+        alpha=0.5,
+        cosine_threshold=2.0,
+    )
+    model_plain, model_cached = _synchronize_models(cfg)
+    feature_cache = FeatureCache(cfg)
+    model_plain.eval()
+    model_cached.eval()
+    x0 = torch.randn(2, 4, 8, 8)
+    t0 = torch.full((2,), 3)
+    y = torch.randint(0, 10, (2,))
+    with torch.no_grad():
+        _ = model_plain(x0, t0, y)
+        _ = model_cached(x0, t0, y, cache_config=cfg, feature_cache=feature_cache)
+    x1 = torch.randn(2, 4, 8, 8)
+    t1 = torch.full((2,), 2)
+    with torch.no_grad():
+        out_plain = model_plain(x1, t1, y)
+        out_cached = model_cached(x1, t1, y, cache_config=cfg, feature_cache=feature_cache)
+    assert torch.allclose(out_plain, out_cached)
+    assert feature_cache.metrics.cache_hits == 0

--- a/train.py
+++ b/train.py
@@ -24,12 +24,42 @@ from copy import deepcopy
 from glob import glob
 from time import time
 import argparse
+import importlib
+import importlib.util
 import logging
 import os
+import sys
+from pathlib import Path
+from types import ModuleType
 
 from models import DiT_models
 from diffusion import create_diffusion
 from diffusers.models import AutoencoderKL
+
+
+def _load_cache_config():
+    try:
+        from diffusers.utils.dit_cache import CacheConfig
+        return CacheConfig
+    except ModuleNotFoundError:
+        cache_path = Path(__file__).resolve().parent / "src" / "diffusers" / "utils" / "dit_cache.py"
+        if not cache_path.exists():
+            raise
+        spec = importlib.util.spec_from_file_location("diffusers.utils.dit_cache", cache_path)
+        if spec is None or spec.loader is None:
+            raise
+        module = importlib.util.module_from_spec(spec)
+        try:
+            parent = importlib.import_module("diffusers.utils")
+        except ModuleNotFoundError:
+            parent = ModuleType("diffusers.utils")
+            sys.modules["diffusers.utils"] = parent
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module.CacheConfig
+
+
+CacheConfig = _load_cache_config()
 
 
 #################################################################################
@@ -113,6 +143,16 @@ def main(args):
     """
     assert torch.cuda.is_available(), "Training currently requires at least one GPU."
 
+    cache_config = CacheConfig.from_flags(
+        enable=args.cache_enable,
+        level=args.cache_level,
+        policy=args.cache_policy,
+        delta=args.cache_delta,
+        alpha=args.cache_alpha,
+        cosine_threshold=args.cache_cosine_threshold,
+        warmup_steps=args.cache_warmup_steps,
+    )
+
     # Setup DDP:
     dist.init_process_group("nccl")
     assert args.global_batch_size % dist.get_world_size() == 0, f"Batch size must be divisible by world size."
@@ -141,7 +181,8 @@ def main(args):
     latent_size = args.image_size // 8
     model = DiT_models[args.model](
         input_size=latent_size,
-        num_classes=args.num_classes
+        num_classes=args.num_classes,
+        cache_config=cache_config,
     )
     # Note that parameter initialization is done within the DiT constructor
     ema = deepcopy(model).to(device)  # Create an EMA of the model for use after training
@@ -265,5 +306,34 @@ if __name__ == "__main__":
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument("--log-every", type=int, default=100)
     parser.add_argument("--ckpt-every", type=int, default=50_000)
+    parser.add_argument("--cache.enable", dest="cache_enable", type=str, default="false")
+    parser.add_argument(
+        "--cache.level",
+        dest="cache_level",
+        type=str,
+        choices=["none", "block", "attn"],
+        default="none",
+    )
+    parser.add_argument(
+        "--cache.policy",
+        dest="cache_policy",
+        type=str,
+        choices=["disabled"],
+        default="disabled",
+    )
+    parser.add_argument("--cache.delta", dest="cache_delta", type=int, default=1)
+    parser.add_argument("--cache.alpha", dest="cache_alpha", type=float, default=1.0)
+    parser.add_argument(
+        "--cache.cosine-threshold",
+        dest="cache_cosine_threshold",
+        type=float,
+        default=1.0,
+    )
+    parser.add_argument(
+        "--cache.warmup-steps",
+        dest="cache_warmup_steps",
+        type=int,
+        default=0,
+    )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## Summary
- extend the cache utilities with block-level blending controls, telemetry, and latency hooks for SmoothCache reuse
- integrate cache contexts into the DiT blocks so cached outputs can be blended per-step and expose tuning flags via the sampling and training CLIs
- add regression tests that confirm SmoothCache matches the baseline when alpha=1.0 or the cosine threshold is set above any feasible similarity

## Testing
- python -m compileall src/diffusers/utils/dit_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68df8d23947c8330871672b691b63f9e