### PR TITLE
Add attention KV cache reuse with configurable blending

### DIFF
--- a/models.py
+++ b/models.py
@@ -11,6 +11,7 @@
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import numpy as np
 import math
 import importlib
@@ -120,6 +121,7 @@ class CachedAttention(nn.Module):
         self.num_heads = num_heads
         head_dim = dim // num_heads
         self.head_dim = head_dim
+        self.embed_dim = dim
         self.scale = qk_scale or head_dim ** -0.5
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
@@ -127,12 +129,45 @@ class CachedAttention(nn.Module):
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
 
+    def _project_q(self, x):
+        b, n, _ = x.shape
+        weight = self.qkv.weight[: self.embed_dim]
+        bias = None if self.qkv.bias is None else self.qkv.bias[: self.embed_dim]
+        q = F.linear(x, weight, bias)
+        q = q.reshape(b, n, self.num_heads, self.head_dim)
+        return q.permute(0, 2, 1, 3)
+
+    def _project_kv(self, x):
+        b, n, _ = x.shape
+        weight = self.qkv.weight[self.embed_dim :]
+        bias = None if self.qkv.bias is None else self.qkv.bias[self.embed_dim :]
+        kv = F.linear(x, weight, bias)
+        kv = kv.reshape(b, n, 2, self.num_heads, self.head_dim)
+        kv = kv.permute(2, 0, 3, 1, 4)
+        return kv[0], kv[1]
+
     def forward(self, x, feature_cache=None, layer_index=None):
         b, n, c = x.shape
-        qkv = self.qkv(x)
-        qkv = qkv.reshape(b, n, 3, self.num_heads, self.head_dim)
-        qkv = qkv.permute(2, 0, 3, 1, 4)
-        q, k, v = qkv[0], qkv[1], qkv[2]
+        cfg_state = None
+        if feature_cache is not None and layer_index is not None:
+            prepare = getattr(feature_cache, "prepare_cfg_attention", None)
+            if prepare is not None:
+                cfg_state = prepare(layer_index, device=x.device, dtype=x.dtype)
+
+        use_shared_context = bool(getattr(cfg_state, "use_shared_context", lambda: False)())
+        use_shared_kv = bool(getattr(cfg_state, "use_shared_kv", lambda: False)())
+
+        if use_shared_context:
+            q = None
+            k = getattr(cfg_state, "key", None)
+            v = getattr(cfg_state, "value", None)
+        elif use_shared_kv:
+            q = self._project_q(x)
+            k = getattr(cfg_state, "key", None)
+            v = getattr(cfg_state, "value", None)
+        else:
+            q = self._project_q(x)
+            k, v = self._project_kv(x)
 
         if feature_cache is not None and layer_index is not None:
             try:
@@ -140,14 +175,30 @@ class CachedAttention(nn.Module):
             except AttributeError:
                 pass
 
-        q = q * self.scale
-        attn = q @ k.transpose(-2, -1)
-        attn = attn.softmax(dim=-1)
-        attn = self.attn_drop(attn)
-        x = (attn @ v).transpose(1, 2).reshape(b, n, c)
-        x = self.proj(x)
-        x = self.proj_drop(x)
-        return x
+        attn = None
+        head_context = None
+        final_context = None
+        if use_shared_context and cfg_state is not None:
+            final_context = cfg_state.context
+        else:
+            if q is None:
+                q = self._project_q(x)
+            q = q * self.scale
+            attn = q @ k.transpose(-2, -1)
+            attn = attn.softmax(dim=-1)
+            attn = self.attn_drop(attn)
+            head_context = attn @ v
+            final_context = head_context.transpose(1, 2).reshape(b, n, c)
+
+        out = self.proj(final_context)
+        out = self.proj_drop(out)
+
+        if feature_cache is not None and layer_index is not None and cfg_state is not None:
+            finalize = getattr(feature_cache, "store_cfg_attention", None)
+            if finalize is not None:
+                finalize(layer_index, k, v, attn=attn, context=final_context, head_context=head_context)
+
+        return out
 
 
 class DiTBlock(nn.Module):
@@ -375,22 +426,74 @@ class DiT(nn.Module):
         """
         Forward pass of DiT, but also batches the unconditional forward pass for classifier-free guidance.
         """
-        # https://github.com/openai/glide-text2im/blob/main/notebooks/text2im.ipynb
-        half = x[: len(x) // 2]
-        combined = torch.cat([half, half], dim=0)
-        model_out = self.forward(
-            combined,
-            t,
-            y,
-            cache_config=cache_config,
-            feature_cache=feature_cache,
-        )
-        # For exact reproducibility reasons, we apply classifier-free guidance on only
-        # three channels by default. The standard approach to cfg applies it to all channels.
-        # This can be done by uncommenting the following line and commenting-out the line following that.
-        # eps, rest = model_out[:, :self.in_channels], model_out[:, self.in_channels:]
-        eps, rest = model_out[:, :3], model_out[:, 3:]
-        cond_eps, uncond_eps = torch.split(eps, len(eps) // 2, dim=0)
+        resolved_config = cache_config or self.cache_config
+        share_value = "off"
+        if resolved_config is not None:
+            share_raw = getattr(resolved_config, "cfg_share", "off")
+            share_value = str(share_raw)
+
+        active_cache = feature_cache
+        share_requested = share_value.lower() != "off"
+        if share_requested and active_cache is None and resolved_config is not None and resolved_config.active:
+            active_cache = FeatureCache(resolved_config)
+
+        batch = x.shape[0]
+        assert batch % 2 == 0, "CFG batches must contain an even number of samples"
+        half = batch // 2
+
+        if share_requested and active_cache is not None:
+            cond_x, uncond_x = torch.split(x, half, dim=0)
+            cond_y, uncond_y = torch.split(y, half, dim=0)
+            cond_t, uncond_t = torch.split(t, half, dim=0)
+
+            cfg_start = getattr(active_cache, "on_cfg_batch_start", None)
+            if cfg_start is not None:
+                cfg_start()
+            cfg_branch = getattr(active_cache, "on_cfg_branch", None)
+            if cfg_branch is not None:
+                cfg_branch("uncond")
+
+            uncond_out = self.forward(
+                uncond_x,
+                uncond_t,
+                uncond_y,
+                cache_config=cache_config,
+                feature_cache=active_cache,
+            )
+
+            if cfg_branch is not None:
+                cfg_branch("cond")
+
+            cond_out = self.forward(
+                cond_x,
+                cond_t,
+                cond_y,
+                cache_config=cache_config,
+                feature_cache=active_cache,
+            )
+
+            cfg_end = getattr(active_cache, "on_cfg_batch_end", None)
+            if cfg_end is not None:
+                cfg_end()
+
+            cond_eps = cond_out[:, :3]
+            cond_rest = cond_out[:, 3:]
+            uncond_eps = uncond_out[:, :3]
+            uncond_rest = uncond_out[:, 3:]
+            rest = torch.cat([cond_rest, uncond_rest], dim=0)
+        else:
+            # https://github.com/openai/glide-text2im/blob/main/notebooks/text2im.ipynb
+            first_half = x[:half]
+            combined = torch.cat([first_half, first_half], dim=0)
+            model_out = self.forward(
+                combined,
+                t,
+                y,
+                cache_config=cache_config,
+                feature_cache=active_cache,
+            )
+            eps, rest = model_out[:, :3], model_out[:, 3:]
+            cond_eps, uncond_eps = torch.split(eps, eps.shape[0] // 2, dim=0)
         half_eps = uncond_eps + cfg_scale * (cond_eps - uncond_eps)
         eps = torch.cat([half_eps, half_eps], dim=0)
         return torch.cat([eps, rest], dim=1)

--- a/sample.py
+++ b/sample.py
@@ -64,6 +64,7 @@ def main(args):
         warmup_steps=args.cache_warmup_steps,
         kv_blend=args.cache_kv_blend,
         reset_on_shape_change=args.cache_reset_on_shape_change,
+        cfg_share=args.cache_cfg_share,
     )
 
     if args.ckpt is None:
@@ -157,6 +158,13 @@ if __name__ == "__main__":
         dest="cache_reset_on_shape_change",
         type=str,
         default="true",
+    )
+    parser.add_argument(
+        "--cache.cfg-share",
+        dest="cache_cfg_share",
+        type=str,
+        choices=["off", "kv", "attn"],
+        default="off",
     )
     args = parser.parse_args()
     main(args)

--- a/sample.py
+++ b/sample.py
@@ -62,6 +62,8 @@ def main(args):
         alpha=args.cache_alpha,
         cosine_threshold=args.cache_cosine_threshold,
         warmup_steps=args.cache_warmup_steps,
+        kv_blend=args.cache_kv_blend,
+        reset_on_shape_change=args.cache_reset_on_shape_change,
     )
 
     if args.ckpt is None:
@@ -137,6 +139,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cache.delta", dest="cache_delta", type=int, default=1)
     parser.add_argument("--cache.alpha", dest="cache_alpha", type=float, default=1.0)
+    parser.add_argument("--cache.kv-blend", dest="cache_kv_blend", type=float, default=0.0)
     parser.add_argument(
         "--cache.cosine-threshold",
         dest="cache_cosine_threshold",
@@ -148,6 +151,12 @@ if __name__ == "__main__":
         dest="cache_warmup_steps",
         type=int,
         default=0,
+    )
+    parser.add_argument(
+        "--cache.reset-on-shape-change",
+        dest="cache_reset_on_shape_change",
+        type=str,
+        default="true",
     )
     args = parser.parse_args()
     main(args)

--- a/train.py
+++ b/train.py
@@ -153,6 +153,7 @@ def main(args):
         warmup_steps=args.cache_warmup_steps,
         kv_blend=args.cache_kv_blend,
         reset_on_shape_change=args.cache_reset_on_shape_change,
+        cfg_share=args.cache_cfg_share,
     )
 
     # Setup DDP:
@@ -343,6 +344,13 @@ if __name__ == "__main__":
         dest="cache_reset_on_shape_change",
         type=str,
         default="true",
+    )
+    parser.add_argument(
+        "--cache.cfg-share",
+        dest="cache_cfg_share",
+        type=str,
+        choices=["off", "kv", "attn"],
+        default="off",
     )
     args = parser.parse_args()
     main(args)

--- a/train.py
+++ b/train.py
@@ -151,6 +151,8 @@ def main(args):
         alpha=args.cache_alpha,
         cosine_threshold=args.cache_cosine_threshold,
         warmup_steps=args.cache_warmup_steps,
+        kv_blend=args.cache_kv_blend,
+        reset_on_shape_change=args.cache_reset_on_shape_change,
     )
 
     # Setup DDP:
@@ -323,6 +325,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cache.delta", dest="cache_delta", type=int, default=1)
     parser.add_argument("--cache.alpha", dest="cache_alpha", type=float, default=1.0)
+    parser.add_argument("--cache.kv-blend", dest="cache_kv_blend", type=float, default=0.0)
     parser.add_argument(
         "--cache.cosine-threshold",
         dest="cache_cosine_threshold",
@@ -334,6 +337,12 @@ if __name__ == "__main__":
         dest="cache_warmup_steps",
         type=int,
         default=0,
+    )
+    parser.add_argument(
+        "--cache.reset-on-shape-change",
+        dest="cache_reset_on_shape_change",
+        type=str,
+        default="true",
     )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
## Summary
- introduce a CachedAttention module that integrates with FeatureCache to reuse key/value tensors across steps
- extend FeatureCache with attention-level storage, blending, and shape-safety controls plus new cache flags
- expose cache.kv-blend and cache.reset-on-shape-change options on sampling and training entrypoints

## Testing
- pytest tests/test_cache_scaffolding.py

------
https://chatgpt.com/codex/tasks/task_e_68df9c23a218833084aae7d37462e8cd